### PR TITLE
Refactoring install commands into install phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ sudo: false
 node_js:
   - "0.12"
 
+install:
+  - npm install
+  - npm install -g grunt-cli
 before_script:
   - "npm update -g npm"
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-  - "npm install -g grunt-cli"


### PR DESCRIPTION
-------------------------------

Having install commands in other phases violates the semantics of the `.travis.yml` configuration. So we have refactored them into the `install` phase.

If the `install` phase is not defined in the `.travis.yml`,  Travis CI runs `npm install` for Node.js projects by default, as explained in the Travis CI docs [here](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Travis-CI-uses-npm). To preserve that original behaviour after refactoring, we have added the `npm install` command as well.

-------------------------------

**Note:** This pull request was generated by an automated tool developed by [The Software REBELs](http://rebels.ece.mcgill.ca/) (a.k.a., the Software Repository Excavation and Build Engineering Labs) of McGill University, Canada. It is part of a research project by [Keheliya Gallaba](http://keheliya.github.io/) under the supervision of [Dr.Shane McIntosh](http://shanemcintosh.org). If you have any questions or feedback about this tool, please feel free to contact the author (keheliya.gallaba@mail.mcgill.ca).